### PR TITLE
Update kokkos_vnode.h for use on AVX2 architectures like AMD's Rome CPUs.

### DIFF
--- a/include/kokkos_vnode.h
+++ b/include/kokkos_vnode.h
@@ -267,7 +267,9 @@ struct VNode<MGComplex<float>,4> {
   VecType permute(const MaskType& mask, const VecTypeGlobal& vec_in)
   {
 	VecType vec_out;
-	vec_out._vdata = _mm256_permutexvar_ps(mask.maskvalue, vec_in._vdata);
+        // NVIDIA FIX: The `_mm256_permutexvar_ps` intrinsic is AVX512 specific, this section is used for AVX machines.            
+        // vec_out._vdata = _mm256_permutexvar_ps(mask.maskvalue, vec_in._vdata);            
+        vec_out._vdata = _mm256_permutevar8x32_ps(vec_in._vdata, mask.maskvalue);
 	return vec_out;
   }
 }; // struct vector length = 8


### PR DESCRIPTION
Fixed misuse of AVX512 intrinsic when AVX2 should be used.